### PR TITLE
uso de 'this' ao invés de 'document' p eventos

### DIFF
--- a/jquery.cpfcnpj.js
+++ b/jquery.cpfcnpj.js
@@ -49,7 +49,7 @@
             var valid = null;
             var control = $(this);
 
-            $(document).on(settings.event, settings.handler,
+            $(this).on(settings.event, settings.handler,
                function () {
                    if (control.val().length == 14 || control.val().length == 18) {
                        if (settings.validate == 'cpf') {


### PR DESCRIPTION
Na linha 52, substitui o _document_ por _this_ para que os eventos possam ser tratados diretamente com o input ao invés do objeto _document_
